### PR TITLE
Add reviews demo notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Każdy notebook odpowiada za konkretny etap analizy i jest powiązany z slajdami
 | 04 | `Text Generation`        | 13–15               | Prompt-engineering i sampling (`temp`, `top_p`)     |
 | 05 | `Summarization`        | 16–17               | BART: streszczenie tekstu |
 | 06 | `Question Answering`   | 18–19               | DistilBERT: odpowiedzi na pytania |
-| –  | **Podsumowanie**         | 20                  | Główne wnioski i propozycje kolejnych kroków       |
+| 07 | `Reviews Transformers` | 20–22               | Analiza recenzji z CSV: sentiment, streszczenia |
+| –  | **Podsumowanie**         | 23                  | Główne wnioski i propozycje kolejnych kroków       |
 
 ---
 

--- a/notebooks/07_reviews_transformers.ipynb
+++ b/notebooks/07_reviews_transformers.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "39a69f37",
+   "metadata": {},
+   "source": [
+    "# Course and Peer Reviews: Transformers Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ada38f58",
+   "metadata": {},
+   "source": [
+    "This notebook loads `course_reviews.csv` and `peer_reviews.csv`, performs basic preprocessing and demonstrates summarization and sentiment analysis using Hugging Face transformers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaf44db2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from transformers import pipeline\n",
+    "from src.utils import clean_text\n",
+    "import matplotlib.pyplot as plt\n",
+    "from nltk.corpus import stopwords\n",
+    "from nltk.tokenize import word_tokenize\n",
+    "import nltk\n",
+    "nltk.download('punkt')\n",
+    "nltk.download('stopwords')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "179bf52d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = Path('data')\n",
+    "course_path = next(data_dir.glob('course_reviews.csv'))\n",
+    "peer_path = next(data_dir.glob('peer_reviews.csv'))\n",
+    "course_df = pd.read_csv(course_path)\n",
+    "peer_df = pd.read_csv(peer_path)\n",
+    "print('Course reviews:', course_df.shape)\n",
+    "print('Peer reviews:', peer_df.shape)\n",
+    "course_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d79ba453",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(course_df.columns)\n",
+    "print(peer_df.columns)\n",
+    "peer_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44e1ad8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def preprocess(text):\n",
+    "    text = clean_text(text)\n",
+    "    tokens = word_tokenize(text)\n",
+    "    sw = set(stopwords.words('english'))\n",
+    "    tokens = [t for t in tokens if t not in sw]\n",
+    "    return ' '.join(tokens)\n",
+    "\n",
+    "course_df['clean_text'] = course_df['review_text'].apply(preprocess)\n",
+    "peer_df['clean_text'] = peer_df['comment'].apply(preprocess)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3099847",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "course_df['rating'].hist()\n",
+    "plt.title('Course review ratings')\n",
+    "plt.show()\n",
+    "peer_df['score'].hist()\n",
+    "plt.title('Peer review scores')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "265f9a21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sentiment = pipeline('sentiment-analysis')\n",
+    "print(sentiment(course_df['clean_text'].iloc[0]))\n",
+    "print(sentiment(peer_df['clean_text'].iloc[0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74a7c537",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarizer = pipeline('summarization')\n",
+    "print('Summary course:', summarizer(course_df['clean_text'].iloc[0])[0]['summary_text'])\n",
+    "print('Summary peer:', summarizer(peer_df['clean_text'].iloc[0])[0]['summary_text'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cde2ae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qa = pipeline('question-answering')\n",
+    "context = course_df['clean_text'].iloc[0]\n",
+    "question = 'What is this review about?'\n",
+    "print(qa(question=question, context=context)['answer'])"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new notebook demonstrating transformers on course and peer reviews
- reference the new notebook in README

## Testing
- `python scripts/download_reviews.py`
- `python scripts/download_peer_reviews.py`


------
https://chatgpt.com/codex/tasks/task_e_686411e4c7288323a1c22537059e0664